### PR TITLE
Add KeyUsageCertSign to genSelfSignedCert

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -247,6 +247,9 @@ func generateSelfSignedCertificate(
 	if err != nil {
 		return cert, err
 	}
+	template.KeyUsage = x509.KeyUsageKeyEncipherment |
+		x509.KeyUsageDigitalSignature |
+		x509.KeyUsageCertSign
 
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {


### PR DESCRIPTION
If it is intentional to leave the key usage out, we can discuss it here. Basically, let a self signed cert verify itself.